### PR TITLE
Add missing extendsFrom directives.

### DIFF
--- a/libs/wuff-plugin/src/main/resources/org/akhikhl/wuff/defaultConfig.groovy
+++ b/libs/wuff-plugin/src/main/resources/org/akhikhl/wuff/defaultConfig.groovy
@@ -458,6 +458,8 @@ wuff {
 
   eclipseVersion('4.6.2') {
 
+    extendsFrom '4.5.2'
+
     eclipseMavenGroup = 'eclipse-neon-sr2'
 
     eclipseMirror = 'http://ftp.fau.de'
@@ -473,6 +475,8 @@ wuff {
   }
 
   eclipseVersion('4.7.2') {
+
+    extendsFrom '4.6.2'
 
     // new Eclipse packging makes it impossible to use the .dmg file, at least not easily!
     suffix_os['macosx'] = 'linux-gtk'
@@ -494,6 +498,8 @@ wuff {
   }
 
     eclipseVersion('4.8.0') {
+
+      extendsFrom '4.7.2'
 
       // new Eclipse packging makes it impossible to use the .dmg file, at least not easily!
       suffix_os['macosx'] = 'linux-gtk'


### PR DESCRIPTION
I tried out your fork of wuff, and it seems to be working well, thanks for maintaining it!

I encountered one issue when building a project with `eclipse-bundle`, where several dependencies such as such as `org.eclipse.swt.$os.$ws.$arch` were not being added by default. Adding these `extendsFrom` directives to the default configuration fixes that, since it now (transitively) inherits from the configuration that adds these dependencies:

```
...
    eclipseBundle {

      project.dependencies {
        compile "${eclipseMavenGroup}:org.eclipse.jface:+"
        compile "${eclipseMavenGroup}:org.eclipse.swt:+"
        compile "${eclipseMavenGroup}:org.eclipse.swt.${current_os_suffix}${current_arch_suffix}:+"
        compile "${eclipseMavenGroup}:org.eclipse.ui:+"
      }
...
```

Would it be possible to merge this, or is there a concrete reason for not having these `extendsFrom` directives?